### PR TITLE
Add ability to lookup via URL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
+  gem "faker"
 end
 
 gem "tailwindcss-rails", "~> 2.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,8 @@ GEM
     drb (2.2.0)
       ruby2_keywords
     erubi (1.12.0)
+    faker (3.2.3)
+      i18n (>= 1.8.11, < 2)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.1)
@@ -315,6 +317,7 @@ DEPENDENCIES
   debug
   dnsruby
   dockerfile-rails (>= 1.6)
+  faker
   importmap-rails
   minitest-retry
   pg (~> 1.5)

--- a/app/controllers/queries_controller.rb
+++ b/app/controllers/queries_controller.rb
@@ -9,6 +9,7 @@ class QueriesController < ApplicationController
     end.order(created_at: :desc)
 
     @query = Query.new(@queries.first&.slice(:type, :server))
+    @limit = params[:limit].to_i.clamp(25, 500)
   end
 
   def show
@@ -21,9 +22,7 @@ class QueriesController < ApplicationController
     @query.session_id = session.id.to_s
 
     if @query.valid?
-      dns_lookup = DNSLookup.new(@query.server_ip)
-      @query.results = dns_lookup.run(@query.domain, @query.type)
-      @query.duration = dns_lookup.duration
+      @query.do_dns_lookup!
       @query.save
 
       redirect_to @query

--- a/app/controllers/redirect_controller.rb
+++ b/app/controllers/redirect_controller.rb
@@ -1,0 +1,23 @@
+class RedirectController < ApplicationController
+
+  def create
+    if params[:domain_name].present?
+      query = Query.new(params.permit(:server, :type, :domain_name))
+      query.type ||= 'A'
+      query.server ||= 'Cloudflare'
+      query.session_id = session.id.to_s
+
+      if query.valid?
+        query.do_dns_lookup!
+        query.save
+
+        redirect_to query_path(query)
+      else
+        redirect_to root_path
+      end
+    else
+      redirect_to root_path
+    end
+  end
+
+end

--- a/app/views/queries/index.html.erb
+++ b/app/views/queries/index.html.erb
@@ -14,7 +14,7 @@
           </tr>
         </thead>
         <tbody class="divide-y divide-neutral-800">
-          <%= render @queries.limit(25) %>
+          <%= render @queries.limit(@limit) %>
         </tbody>
       </table>
     </div>

--- a/app/views/queries/show.html.erb
+++ b/app/views/queries/show.html.erb
@@ -18,6 +18,7 @@
       <span><%= @query.duration_ms %></span>
     </div>
   </div>
+
   <%= turbo_frame_tag :results, class: "block bg-black p-4 rounded-lg sm:text-lg border-2 border-neutral-800 overflow-hidden" do %>
     <%
       def button_classes(button)
@@ -39,13 +40,25 @@
         <% end %>
       </div>
       <% if @query.results.key?('zone') && @view == 'zone' %>
-        <pre data-controller="highlight" class="mt-1 opacity-0 transition"><code class="language-dns"><%= @query.results['zone'] %></code></pre>
+        <pre data-controller="highlight" data-highlight-server-value="<%= @query.server.downcase %>" class="mt-1 opacity-0 transition"><code class="language-dns"><%= @query.results['zone'] %></code></pre>
       <% else %>
-        <pre data-controller="highlight" class="mt-1 opacity-0 transition"><code class="language-json"><%= JSON.pretty_generate(@query.results['json'] || @query.results) %></code></pre>
+        <pre data-controller="highlight" data-highlight-server-value="<%= @query.server.downcase %>" class="mt-1 opacity-0 transition"><code class="language-json"><%= JSON.pretty_generate(@query.results['json'] || @query.results) %></code></pre>
       <% end %>
     </div>
   <% end %>
+
+  <div class="grid grid-cols-1 gap-3 bg-black p-4 rounded-lg sm:text-lg border-2 border-neutral-800">
+    <div class="flex flex-col">
+      <span class="text-lime-500 font-semibold">This Lookup</span>
+      <%= text_field_tag :query, query_url(@query), class: "form-field__input mt-2", readonly: true, onclick: "this.select();" %>
+    </div>
+    <div class="flex flex-col">
+      <span class="text-lime-500 font-semibold">Realtime Lookup</span>
+      <%= text_field_tag :realtime_query, redirect_url(@query.redirect_params), class: "form-field__input mt-2", readonly: true, onclick: "this.select();" %>
+    </div>
+  </div>
 </div>
+
 <div class="flex p-4 text-xs text-neutral-600 justify-between">
   <% if @query.session_id == session.id.to_s %>
     <%= button_to "Remove", query_path(@query), method: :delete,

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,5 +24,7 @@ module D53Co
     #
     config.time_zone = "Eastern Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    config.action_view.field_error_proc = ->(html_tag, instance) { html_tag }
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,4 +12,7 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root "queries#index"
   resources :queries, only: %i[index create show destroy]
+
+  get "((:server)/:type)/:domain_name" => "redirect#create",
+    constraints: { domain_name: /([^\/]+?)(?=\.json|\.html|$|\/)/ }, as: :redirect
 end

--- a/test/controllers/queries_controller_test.rb
+++ b/test/controllers/queries_controller_test.rb
@@ -11,13 +11,14 @@ class QueriesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should create query" do
+    domain = Faker::Internet.unique.domain_name
     assert_difference("Query.count") do
       post queries_url, params: {
-        query: { domain: 'create-google.com', server: 'Cloudflare', type: 'A' }
+        query: { domain: domain, server: 'Cloudflare', type: 'A' }
       }
     end
 
-    assert_redirected_to query_url(Query.find_by(domain: 'create-google.com'))
+    assert_redirected_to query_url(Query.find_by(domain: domain))
   end
 
   test "should show query" do

--- a/test/controllers/redirect_controller_test.rb
+++ b/test/controllers/redirect_controller_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class RedirectControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @domain = Faker::Internet.unique.domain_name
+  end
+
+  test "should create query with server, type, and domain" do
+    get "/google/mx/#{@domain}"
+
+    assert_redirected_to query_path(new_query)
+    assert_equal 'Google', new_query.server
+    assert_equal 'MX', new_query.type
+    assert_equal @domain, new_query.domain
+  end
+
+  test "should create query with type and domain" do
+    get "/mx/#{@domain}"
+
+    assert_redirected_to query_path(new_query)
+    assert_equal 'Cloudflare', new_query.server
+    assert_equal 'MX', new_query.type
+    assert_equal @domain, new_query.domain
+  end
+
+  test "should create query with domain" do
+    get "/#{@domain}"
+
+    assert_redirected_to query_path(new_query)
+    assert_equal 'Cloudflare', new_query.server
+    assert_equal 'A', new_query.type
+    assert_equal @domain, new_query.domain
+  end
+
+  private
+
+  def new_query
+    @new_query ||= Query.find_by(domain: @domain)
+  end
+end

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -16,7 +16,57 @@
 require "test_helper"
 
 class QueryTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "domain setter will strip paths" do
+    query = Query.new(domain: 'd53.com/path')
+    assert_equal 'd53.com', query.domain
+  end
+
+  test "domain setter will strip just a trailing slash" do
+    query = Query.new(domain: 'd53.com/')
+    assert_equal 'd53.com', query.domain
+  end
+
+  test "domain setter will strip protocols" do
+    query1 = Query.new(domain: 'http://d53.com')
+    query2 = Query.new(domain: 'ftp://d53.com')
+    assert_equal 'd53.com', query1.domain
+    assert_equal 'd53.com', query2.domain
+  end
+
+  test "domain setter will strip spaces" do
+    query = Query.new(domain: 'd53 .com')
+    assert_equal 'd53.com', query.domain
+  end
+
+  test "domain setter will strip protocol, path, and spaces togather" do
+    query = Query.new(domain: 'http://d53.com/this path')
+    assert_equal 'd53.com', query.domain
+  end
+
+  test "server setter will only set known server" do
+    query_with_known_server = Query.new(server: 'Cloudflare')
+    query_with_unknown_server = Query.new(server: 'Flarecloud')
+
+    assert_equal 'Cloudflare', query_with_known_server.server
+    assert_equal '1.1.1.1', query_with_known_server.server_ip
+    assert_nil query_with_unknown_server.server
+    assert_nil query_with_unknown_server.server_ip
+  end
+
+  test "server setter is case insensitive" do
+    query = Query.new(server: 'cloudflare')
+    assert_equal 'Cloudflare', query.server
+  end
+
+  test "type setter will only set known type" do
+    query_with_known_type = Query.new(type: 'A')
+    query_with_unknown_type = Query.new(type: 'B')
+    assert_equal 'A', query_with_known_type.type
+    assert_nil query_with_unknown_type.type
+  end
+
+  test "type setter is case insensitive" do
+    query = Query.new(type: 'a')
+    assert_equal 'A', query.type
+  end
 end


### PR DESCRIPTION
- New ability to lookup using /:server/:type/:domain, /:type/:domain, or /:domain. Server will default to Cloudflare and Type will default to A record if not passed in
- Improved query setters
- Improved testing