### PR TITLE
Restrict redirect routes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,9 @@
 class ApplicationController < ActionController::Base
   default_form_builder ApplicationFormBuilder
+
+  private
+
+  def not_found
+    raise ActionController::RoutingError.new("Not Found")
+  end
 end

--- a/app/controllers/redirect_controller.rb
+++ b/app/controllers/redirect_controller.rb
@@ -1,22 +1,17 @@
 class RedirectController < ApplicationController
 
   def create
-    if params[:domain_name].present?
-      query = Query.new(params.permit(:server, :type, :domain_name))
-      query.type ||= 'A'
-      query.server ||= 'Cloudflare'
-      query.session_id = session.id.to_s
+    query = Query.new(params.permit(:server, :type, :domain_name))
+    query.server ||= 'Cloudflare'
+    query.session_id = session.id.to_s
 
-      if query.valid?
-        query.do_dns_lookup!
-        query.save
+    if query.valid?
+      query.do_dns_lookup!
+      query.save
 
-        redirect_to query_path(query)
-      else
-        redirect_to root_path
-      end
+      redirect_to query_path(query)
     else
-      redirect_to root_path
+      not_found
     end
   end
 

--- a/app/javascript/controllers/highlight_controller.js
+++ b/app/javascript/controllers/highlight_controller.js
@@ -30,10 +30,18 @@ export default class extends Controller {
       );
     }
 
-    const stringRegex = /(\t|\n)([a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,6})/i;
+    const stringRegex = /(\t|\n)([a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,6}\.)/i;
     while ((match = stringRegex.exec(this.element.innerHTML)) !== null) {
       this.element.innerHTML = this.element.innerHTML.replace(
         match[0], `${match[1]}${this.#recordLink(match[2])}`
+      );
+    }
+
+    const spaceSurroundedString = /(\s)([a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,6}\.\s)/i;
+    while ((match = spaceSurroundedString.exec(this.element.innerHTML)) !== null) {
+      console.log(match)
+      this.element.innerHTML = this.element.innerHTML.replace(
+        match[0], ` ${match[1]}${this.#recordLink(match[2].replace(/\s/g, ''))} `
       );
     }
   }
@@ -41,12 +49,12 @@ export default class extends Controller {
   #recordLink(record) {
     const ipv4Regex = /^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/;
     const ipv6Regex = /(?:^|(?<=\s))(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))(?=\s|$)/;
-    const domainRegex = /^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,6}$/i;
+    const domainRegex = /^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,6}\.$/i;
 
     if (ipv4Regex.test(record) || ipv6Regex.test(record)) {
-      return `<a href="/${this.serverValue}/ptr/${record}" class="underline hover:no-underline">${record}</a>`;
+      return `<a href="/${this.serverValue}/ptr/${record.replace(/\.$/, '')}" class="underline hover:no-underline">${record}</a>`;
     } else if (domainRegex.test(record)) {
-      return `<a href="/${this.serverValue}/a/${record}" class="underline hover:no-underline">${record}</a>`;
+      return `<a href="/${this.serverValue}/a/${record.replace(/\.$/, '')}" class="underline hover:no-underline">${record}</a>`;
     } else {
       return record;
     }

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -48,6 +48,7 @@ class Query < ApplicationRecord
 
     value.gsub!(/(^\w+:|^)\/\//, '') # remove protocols
     value.gsub!(/\/(?:[^\/]|\/(?!$))*$/, '') # remove path
+    value.gsub!(/\.$/, '') # remove trailing period
     value.delete!(' ') # remove any spaces
     value.downcase!
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,10 @@ Rails.application.routes.draw do
   root "queries#index"
   resources :queries, only: %i[index create show destroy]
 
-  get "((:server)/:type)/:domain_name" => "redirect#create",
-    constraints: { domain_name: /([^\/]+?)(?=\.json|\.html|$|\/)/ }, as: :redirect
+  get "(:server)/:type/:domain_name" => "redirect#create",
+    constraints: {
+      server: Regexp.new(Query.servers.keys.join("|"), "i"),
+      type: Regexp.new(Query.types.join("|"), "i"),
+      domain_name: /([^\/]+?)(?=\.json|\.html|$|\/)/
+    }, as: :redirect
 end

--- a/test/controllers/redirect_controller_test.rb
+++ b/test/controllers/redirect_controller_test.rb
@@ -23,13 +23,29 @@ class RedirectControllerTest < ActionDispatch::IntegrationTest
     assert_equal @domain, new_query.domain
   end
 
-  test "should create query with domain" do
+  test "should 404 unless type and domain" do
     get "/#{@domain}"
+    assert_response :not_found
+  end
 
-    assert_redirected_to query_path(new_query)
-    assert_equal 'Cloudflare', new_query.server
-    assert_equal 'A', new_query.type
-    assert_equal @domain, new_query.domain
+  test "should 404 unless valid type" do
+    get "/x/#{@domain}"
+    assert_response :not_found
+  end
+
+  test "should 404 unless server" do
+    get "/flarecloud/a/#{@domain}"
+    assert_response :not_found
+  end
+
+  test "should allow case insensitive type" do
+    get "/A/#{@domain}"
+    assert_response :redirect
+  end
+
+  test "should allow case insensitive server" do
+    get "/GoOgLe/a/#{@domain}"
+    assert_response :redirect
   end
 
   private

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -17,56 +17,61 @@ require "test_helper"
 
 class QueryTest < ActiveSupport::TestCase
   test "domain setter will strip paths" do
-    query = Query.new(domain: 'd53.com/path')
-    assert_equal 'd53.com', query.domain
+    query = Query.new(domain: "d53.com/path")
+    assert_equal "d53.com", query.domain
   end
 
   test "domain setter will strip just a trailing slash" do
-    query = Query.new(domain: 'd53.com/')
-    assert_equal 'd53.com', query.domain
+    query = Query.new(domain: "d53.com/")
+    assert_equal "d53.com", query.domain
   end
 
   test "domain setter will strip protocols" do
-    query1 = Query.new(domain: 'http://d53.com')
-    query2 = Query.new(domain: 'ftp://d53.com')
-    assert_equal 'd53.com', query1.domain
-    assert_equal 'd53.com', query2.domain
+    query1 = Query.new(domain: "http://d53.com")
+    query2 = Query.new(domain: "ftp://d53.com")
+    assert_equal "d53.com", query1.domain
+    assert_equal "d53.com", query2.domain
   end
 
   test "domain setter will strip spaces" do
-    query = Query.new(domain: 'd53 .com')
-    assert_equal 'd53.com', query.domain
+    query = Query.new(domain: "d53 .com")
+    assert_equal "d53.com", query.domain
   end
 
   test "domain setter will strip protocol, path, and spaces togather" do
-    query = Query.new(domain: 'http://d53.com/this path')
-    assert_equal 'd53.com', query.domain
+    query = Query.new(domain: "http://d53.com/this path")
+    assert_equal "d53.com", query.domain
+  end
+
+  test "domain setter will strip trailing period" do
+    query = Query.new(domain: "d53.co.")
+    assert_equal "d53.co", query.domain
   end
 
   test "server setter will only set known server" do
-    query_with_known_server = Query.new(server: 'Cloudflare')
-    query_with_unknown_server = Query.new(server: 'Flarecloud')
+    query_with_known_server = Query.new(server: "Cloudflare")
+    query_with_unknown_server = Query.new(server: "Flarecloud")
 
-    assert_equal 'Cloudflare', query_with_known_server.server
-    assert_equal '1.1.1.1', query_with_known_server.server_ip
+    assert_equal "Cloudflare", query_with_known_server.server
+    assert_equal "1.1.1.1", query_with_known_server.server_ip
     assert_nil query_with_unknown_server.server
     assert_nil query_with_unknown_server.server_ip
   end
 
   test "server setter is case insensitive" do
-    query = Query.new(server: 'cloudflare')
-    assert_equal 'Cloudflare', query.server
+    query = Query.new(server: "cloudflare")
+    assert_equal "Cloudflare", query.server
   end
 
   test "type setter will only set known type" do
-    query_with_known_type = Query.new(type: 'A')
-    query_with_unknown_type = Query.new(type: 'B')
-    assert_equal 'A', query_with_known_type.type
+    query_with_known_type = Query.new(type: "A")
+    query_with_unknown_type = Query.new(type: "B")
+    assert_equal "A", query_with_known_type.type
     assert_nil query_with_unknown_type.type
   end
 
   test "type setter is case insensitive" do
-    query = Query.new(type: 'a')
-    assert_equal 'A', query.type
+    query = Query.new(type: "a")
+    assert_equal "A", query.type
   end
 end


### PR DESCRIPTION
The redirect route was allowing too much through. Removed ability to query by domain without a record type since it's prone to many unintentional requests. Must include at least a valid type.